### PR TITLE
Upgrade to OpenStudio 3.8 & Ruby 3.2.2

### DIFF
--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -3,6 +3,7 @@ name: RNM-gem CI
 
 on:
   # push:
+  workflow_dispatch:
   schedule:
     # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
     # 5:23 am UTC (11:23pm MDT the day before) every weekday night in MDT
@@ -19,7 +20,7 @@ jobs:
   weeknight-tests:
     runs-on: ubuntu-latest
     container:
-      image: docker://nrel/openstudio:3.7.0
+      image: docker://nrel/openstudio:3.8.0
     steps:
       - uses: actions/checkout@v4
       - name: set git config options

--- a/.github/workflows/nightly_ci_build.yml
+++ b/.github/workflows/nightly_ci_build.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Update gems
         run: |
           ruby --version
-          bundle update
-          bundle exec certified-update
+          bundle install
       - name: Run Rspec
         run: bundle exec rspec
       - name: Upload artifacts

--- a/Gemfile
+++ b/Gemfile
@@ -7,9 +7,9 @@ gemspec
 allow_local = ENV['FAVOR_LOCAL_GEMS']
 
 # pin this dependency to avoid unicode_normalize error
-gem 'addressable', '2.8.1'
+# gem 'addressable', '2.8.1'
 # pin this dependency to avoid using racc dependency (which has native extensions)
-gem 'parser', '3.2.2.2'
+# gem 'parser', '3.2.2.2'
 
 # Below is an example of how to configure the gemfile for developing with local gems
 # modify as appropriate
@@ -17,5 +17,5 @@ gem 'parser', '3.2.2.2'
 # if allow_local && File.exists?('../urbanopt-geojson-gem')
   # gem 'urbanopt-geojson', path: '../urbanopt-geojson-gem'
 # elsif allow_local
-#  gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'os37'
+ gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'os38'
 # end

--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,6 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 # elsif allow_local
  gem 'urbanopt-geojson', github: 'URBANopt/urbanopt-geojson-gem', branch: 'os38'
 # end
+
+# Temporary! Remove this once core-gem is merged/released
+gem 'urbanopt-core', github: 'URBANopt/urbanopt-core-gem', branch: 'os38'

--- a/lib/urbanopt/rnm/carson_eq.rb
+++ b/lib/urbanopt/rnm/carson_eq.rb
@@ -120,14 +120,14 @@ module URBANopt
 
       # method applying a similar concept of the Carson equation, but for obtaining the primitive potential coeff matrix
       # for obtaining the lines capacitance
-      def get_primitive_potential_coeff_matrix(diamaters, images_matrix, dist_matrix)
+      def get_primitive_potential_coeff_matrix(diameters, images_matrix, dist_matrix)
         n_rows = images_matrix.length
         n_cols = images_matrix.length
         primitive_potential_coeff_matrix = Array.new(n_rows) { Array.new(n_rows) }
         for i in 0..n_rows - 1
           for j in 0..n_cols - 1
             if i == j
-              primitive_potential_coeff_matrix[i][j] = 11.17689 * Math.log(images_matrix[i][j] / (diamaters[i] / 2)) # assuming relative permittivity of air of 1.4240 x 10 mF/mile
+              primitive_potential_coeff_matrix[i][j] = 11.17689 * Math.log(images_matrix[i][j] / (diameters[i] / 2)) # assuming relative permittivity of air of 1.4240 x 10 mF/mile
             else
               primitive_potential_coeff_matrix[i][j] = 11.17689 * Math.log(images_matrix[i][j] / dist_matrix[i][j]) # assuming relative permittivity of air of 1.4240 x 10 mF/mile
             end
@@ -202,7 +202,7 @@ module URBANopt
         else # now computing the capacitance for UG concentric neutral power lines
           material_permettivity = 2.3 # assuming using the minimum permittivity value for "cross-linked polyethlyene", as the insulation material
           free_space_permittivity = 0.0142 # in microfaraday/mile
-          radius = (wire_list.outside_diamater_neutral[0] - wire_list.diameter_n_strand[0]) / 2 # in mm
+          radius = (wire_list.outside_diameter_neutral[0] - wire_list.diameter_n_strand[0]) / 2 # in mm
           radius_ft = si_to_imperial_units(radius, 'mm', 'ft')
           radius_neutral_ft = si_to_imperial_units(wire_list.diameter_n_strand[0] / 2, 'mm', 'ft')
           radius_conductor_ft = diameters_conductors_ft[0] / 2
@@ -232,7 +232,7 @@ module URBANopt
         end
         if !wire_list.r_neutral[0].nil? # computing parameters for concentric neutrals wires
           for j in 0..conc_neutrals - 1
-            radius = (wire_list.outside_diamater_neutral[j] - wire_list.diameter_n_strand[j]) / 2
+            radius = (wire_list.outside_diameter_neutral[j] - wire_list.diameter_n_strand[j]) / 2
             wire_list.gmr.push(wire_list.gmr_neutral[j] * wire_list.neutral_strands[j] * (radius**(wire_list.neutral_strands[j] - 1))**(1 / wire_list.neutral_strands[j]))
             wire_list.r.push(wire_list.r_neutral[j] / wire_list.neutral_strands[j])
             for k in 0..conc_neutrals - 1
@@ -299,7 +299,7 @@ module URBANopt
                 wire_list.gmr_neutral.push(wires['WIRES CATALOG'][k]['gmr neutral (mm)'])
                 wire_list.neutral_strands.push(wires['WIRES CATALOG'][k]['# concentric neutral strands'])
                 wire_list.diameter_n_strand.push(wires['WIRES CATALOG'][k]['concentric diameter neutral strand (mm)'])
-                wire_list.outside_diamater_neutral.push(wires['WIRES CATALOG'][k]['concentric neutral outside diameter (mm)'])
+                wire_list.outside_diameter_neutral.push(wires['WIRES CATALOG'][k]['concentric neutral outside diameter (mm)'])
               end
             end
           end

--- a/lib/urbanopt/rnm/consumers.rb
+++ b/lib/urbanopt/rnm/consumers.rb
@@ -123,7 +123,7 @@ module URBANopt
           when @lv_limit[:single_phase]..@lv_limit[:three_phase] # defined from the catalog (from the wires)
             phases = 3
             voltage_default = 0.48
-            # MV and 3 phases untill 16 MVA, defined by the SMART-DS project
+            # MV and 3 phases until 16 MVA, defined by the SMART-DS project
           when @lv_limit[:three_phase]..16000
             phases = 3
             voltage_default = 12.47

--- a/lib/urbanopt/rnm/geojson_input.rb
+++ b/lib/urbanopt/rnm/geojson_input.rb
@@ -37,7 +37,7 @@ module URBANopt
           # creating variables for x, y for each node, with the right street inclination
           x_uniform = uniform_distance * (distance_x / distance)
           y_uniform = uniform_distance * (distance_y / distance)
-          n = 1 # counter to keep track when the number of intervals for each "distnce" is reached
+          n = 1 # counter to keep track when the number of intervals for each "distance" is reached
           # creating nodes in the coordinates array with the right street inclination and uniform distance among each others
           while n <= intervals
             id = identifier.to_s + "_#{i}"
@@ -64,7 +64,7 @@ module URBANopt
       # and it returns the coordinates and id of the closest node of the building to the street
       ## The new algorithm developed calculates an approximate distance: (x+y)/2, of each building-node with each street-node and compares it with the "minimum_distance"
       # this approximate distance has been defined in order to be able to disregard all the distances which are greater than the "minimum distance" computed until that moment, without being required to compute the Pithagorean Theorem, which requires a long computational time.
-      # Therefore (x+y)/2 has been computed knowing that: if the minimum length of the hypothenuse of a right triangle is when the triangle is isosceles so when the hyphothenuse (d) is equal to d = sqrt(2)*x (where x is the distance among the nodes on the x-axis),
+      # Therefore (x+y)/2 has been computed knowing that: if the minimum length of the hypotenuse of a right triangle is when the triangle is isosceles so when the hyphothenuse (d) is equal to d = sqrt(2)*x (where x is the distance among the nodes on the x-axis),
       # so we can assume that x = (x+y)/2, than if d = sqrt(2)*((x+y)/2) > (x+y)/2 > minimum_distance
       # than it confirmes that x and y can be disregarded and there is no need to compute the real distance for that node since the approximate distance value (which represents the minimum possible distance for the sum of those catheti)
       # is greater than the minimum_distance that it is been compared with.
@@ -82,7 +82,7 @@ module URBANopt
               distance = (x**2 + y**2)**0.5 # the real distance between the building node and the street node is computed
               if distance < dist_min # if the new distance is lower than the minimum distance found until that moment, than this new "distance" value will be set as the minimum distance between the building node and the street node
                 dist_min = distance
-                chosen_coord = building[j] # assigning the node coordinates values and id of the building with the minimium distance to the street to chose_coord variable
+                chosen_coord = building[j] # assigning the node coordinates values and id of the building with the minimum distance to the street to chose_coord variable
               end
             end
             end
@@ -91,7 +91,7 @@ module URBANopt
       end
 
       # defining a method for parsing the coordinates of the substations to be passed in the RNM-US model
-      # choose the closes coord to the street or the one in the midle of the polygon since the sub is far away from district and streets
+      # choose the closes coord to the street or the one in the middle of the polygon since the sub is far away from district and streets
       def sub_coordinates(points_coord, id)
         x_utm = []
         y_utm = []
@@ -123,7 +123,7 @@ module URBANopt
         streets = geojson_hash
         puts "SCENARIO FEATURES: #{scenario_features}"
         # parsing the options defined by the user to run the RNM-US with a certain % of UG cables and designing the network with only LV nodes
-        # to be consistent in case several case-studies are run to have an homogenous parameter on how to compare the same buildings with different energy consumption
+        # to be consistent in case several case-studies are run to have an homogeneous parameter on how to compare the same buildings with different energy consumption
         # Use defaults and warn user if these fields are unset
         if streets.key?('project') && streets['project'].key?('underground_cables_ratio')
           ug_ratio = streets['project']['underground_cables_ratio'].to_f

--- a/lib/urbanopt/rnm/input_files.rb
+++ b/lib/urbanopt/rnm/input_files.rb
@@ -42,7 +42,7 @@ module URBANopt
         end
       end
 
-      # finding the limits on LV defined by the equipments in the catalog
+      # finding the limits on LV defined by the equipment in the catalog
       def catalog_limits
         catalog = JSON.parse(File.read(@extended_catalog_path))
         limit = Hash.new(0)

--- a/lib/urbanopt/rnm/logger.rb
+++ b/lib/urbanopt/rnm/logger.rb
@@ -9,7 +9,7 @@ module URBANopt
   module RNM
     @@logger = Logger.new($stdout)
 
-    # Definining class variable "@@logger" to log errors, info and warning messages.
+    # Defining class variable "@@logger" to log errors, info and warning messages.
     def self.logger
       @@logger
     end

--- a/lib/urbanopt/rnm/oh_ug_rate.rb
+++ b/lib/urbanopt/rnm/oh_ug_rate.rb
@@ -53,7 +53,7 @@ module URBANopt
         @av_height = (height_sum / (i + 1)).to_f.round(2)
       end
 
-      # defining a method which defines the "threshold height", in an iterative way and adding 0.1m of height until the threhold limit is reached
+      # defining a method which defines the "threshold height", in an iterative way and adding 0.1m of height until the threshold limit is reached
       # when the % of streets in the district above the threshold is equal to the UG rate defined by the user
       def threshold_height(street_type, ug_ratio)
         h_threshold = 0

--- a/lib/urbanopt/rnm/prosumers.rb
+++ b/lib/urbanopt/rnm/prosumers.rb
@@ -184,7 +184,7 @@ module URBANopt
           when @lv_limit[:single_phase]..@lv_limit[:three_phase] # defined from the catalog (from the wires)
             phases = 3
             voltage_default = 0.48
-          # MV and 3 phases untill 16 MVA defined by SMART-DS project
+          # MV and 3 phases until 16 MVA defined by SMART-DS project
           when @lv_limit[:three_phase]..16000
             phases = 3
             voltage_default = 12.47

--- a/lib/urbanopt/rnm/substation_location.rb
+++ b/lib/urbanopt/rnm/substation_location.rb
@@ -10,7 +10,7 @@ module URBANopt
   module RNM
     class PrimarySubstation
       # attr_accessor :x, :y, :id
-      # choose the closest coord to the street or the one in the midle of the polygon since the sub is far away from district and streets
+      # choose the closest coord to the street or the one in the middle of the polygon since the sub is far away from district and streets
       def coordinates(points_coord, id)
         x_utm = []
         y_utm = []

--- a/lib/urbanopt/rnm/version.rb
+++ b/lib/urbanopt/rnm/version.rb
@@ -5,6 +5,6 @@
 
 module URBANopt
   module RNM
-    VERSION = '0.7.0'.freeze
+    VERSION = '0.8.0'.freeze
   end
 end

--- a/lib/urbanopt/rnm/wires_class.rb
+++ b/lib/urbanopt/rnm/wires_class.rb
@@ -12,7 +12,7 @@ require 'matrix'
 module URBANopt
   module RNM
     class WiresExtendedCatalog
-      attr_accessor :x, :height, :gmr, :r, :ampacity, :diameter, :phase, :name, :type, :r_neutral, :gmr_neutral, :neutral_strands, :diameter_n_strand, :outside_diamater_neutral
+      attr_accessor :x, :height, :gmr, :r, :ampacity, :diameter, :phase, :name, :type, :r_neutral, :gmr_neutral, :neutral_strands, :diameter_n_strand, :outside_diameter_neutral
 
       def initialize
         self.x = []
@@ -28,7 +28,7 @@ module URBANopt
         self.gmr_neutral = []
         self.neutral_strands = []
         self.diameter_n_strand = []
-        self.outside_diamater_neutral = []
+        self.outside_diameter_neutral = []
       end
     end
   end

--- a/urbanopt-rnm-us-gem.gemspec
+++ b/urbanopt-rnm-us-gem.gemspec
@@ -21,26 +21,18 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib', 'catalogs']
-  spec.required_ruby_version = '~> 3.2.2'
+  # We support exactly Ruby v3.2.2 because os-extension requires bundler==2.4.10 and that requires Ruby 3.2.2: https://stdgems.org/bundler/
+  # It would be nice to be able to use newer patches of Ruby 3.2, which would require os-extension to relax its dependency on bundler.
+  spec.required_ruby_version = '3.2.2'
 
   spec.add_dependency 'certified', '~> 1'
-  # Faraday version is set by extension-gem
-  spec.add_dependency 'faraday', '~> 1.0.1'
   spec.add_dependency 'geoutm', '~> 1.0.2'
-  # Matrix is in stdlib, but needs to be specifically added here for compatibility with Ruby 3.2.2
+  # Matrix is in stdlib, but needs to be specifically added here for compatibility with Ruby 3.2
   spec.add_dependency 'matrix', '~> 0.4.2'
   spec.add_dependency 'rubyzip', '~> 2.3.2'
   # spec.add_dependency 'urbanopt-geojson', '~> 0.11.1'
 
-  # bundler version is set by extension-gem
-  spec.add_development_dependency 'bundler', '~> 2.4.10'
-  spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
-  # parallel version is set by extension-gem
-  spec.add_development_dependency 'parallel', '~> 1.19.1'
-  spec.add_development_dependency 'rubocop-checkstyle_formatter', '~> 0.6.0'
-  # Rubocop-performance version is set by extension-gem
-  spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
 end

--- a/urbanopt-rnm-us-gem.gemspec
+++ b/urbanopt-rnm-us-gem.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |spec|
   # It would be nice to be able to use newer patches of Ruby 3.2, which would require os-extension to relax its dependency on bundler.
   spec.required_ruby_version = '3.2.2'
 
-  spec.add_dependency 'certified', '~> 1'
   spec.add_dependency 'geoutm', '~> 1.0.2'
   # Matrix is in stdlib, but needs to be specifically added here for compatibility with Ruby 3.2
   spec.add_dependency 'matrix', '~> 0.4.2'

--- a/urbanopt-rnm-us-gem.gemspec
+++ b/urbanopt-rnm-us-gem.gemspec
@@ -21,21 +21,26 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib', 'catalogs']
-  spec.required_ruby_version = '~> 3.2'
+  spec.required_ruby_version = '~> 3.2.2'
 
   spec.add_dependency 'certified', '~> 1'
-  spec.add_dependency 'faraday', '~> 2.10.0'
+  # Faraday version is set by extension-gem
+  spec.add_dependency 'faraday', '~> 1.0.1'
   spec.add_dependency 'geoutm', '~> 1.0.2'
+  # Matrix is in stdlib, but needs to be specifically added here for compatibility with Ruby 3.2.2
+  spec.add_dependency 'matrix', '~> 0.4.2'
   spec.add_dependency 'rubyzip', '~> 2.3.2'
   # spec.add_dependency 'urbanopt-geojson', '~> 0.11.1'
 
+  # bundler version is set by extension-gem
   spec.add_development_dependency 'bundler', '~> 2.4.10'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
-  # pin this dependency:
-  spec.add_development_dependency 'parallel', '~> 1.25.1'
+  # parallel version is set by extension-gem
+  spec.add_development_dependency 'parallel', '~> 1.19.1'
   spec.add_development_dependency 'rubocop-checkstyle_formatter', '~> 0.6.0'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.21'
+  # Rubocop-performance version is set by extension-gem
+  spec.add_development_dependency 'rubocop-performance', '~> 1.20'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
 end

--- a/urbanopt-rnm-us-gem.gemspec
+++ b/urbanopt-rnm-us-gem.gemspec
@@ -21,21 +21,21 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib', 'catalogs']
-  spec.required_ruby_version = '~> 2.7.0'
+  spec.required_ruby_version = '~> 3.2'
 
   spec.add_dependency 'certified', '~> 1'
-  spec.add_dependency 'faraday', '~> 1.0.1'
+  spec.add_dependency 'faraday', '~> 2.10.0'
   spec.add_dependency 'geoutm', '~> 1.0.2'
   spec.add_dependency 'rubyzip', '~> 2.3.2'
-  spec.add_dependency 'urbanopt-geojson', '~> 0.11.1'
+  # spec.add_dependency 'urbanopt-geojson', '~> 0.11.1'
 
-  spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'rake', '~> 13.1'
-  spec.add_development_dependency 'rspec', '~> 3.12'
+  spec.add_development_dependency 'bundler', '~> 2.4.10'
+  spec.add_development_dependency 'rake', '~> 13.2'
+  spec.add_development_dependency 'rspec', '~> 3.13'
   # pin this dependency:
-  spec.add_development_dependency 'parallel', '~> 1.19.1'
-  spec.add_development_dependency 'rubocop-checkstyle_formatter', '~> 0.4.0'
-  spec.add_development_dependency 'rubocop-performance', '~> 1.11.3'
-  spec.add_development_dependency 'simplecov', '~> 0.18.2'
+  spec.add_development_dependency 'parallel', '~> 1.25.1'
+  spec.add_development_dependency 'rubocop-checkstyle_formatter', '~> 0.6.0'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.21'
+  spec.add_development_dependency 'simplecov', '~> 0.22.0'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8.0'
 end


### PR DESCRIPTION
The current version of OpenStudio, [v3.8](https://github.com/NREL/OpenStudio/releases) includes a major breaking change to move from Ruby 2.7.2 to Ruby 3.2.2.